### PR TITLE
Makefile, systemd files: switch to DynamicUser=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,7 @@
 BINDIR ?= /usr/bin
 UNITDIR ?= /lib/systemd/system
 UDEVDIR ?= /lib/udev/rules.d
-TMPFILESDIR ?= /usr/lib/tmpfiles.d
 SHAREDIR ?= /usr/share/
-SPEAKERSAFETYD_GROUP ?= speakersafetyd
-SPEAKERSAFETYD_USER ?= speakersafetyd
 
 all:
 	cargo build --release
@@ -23,12 +20,9 @@ install-data:
 	install -pm0644 95-speakersafetyd.rules $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	install -dDm0755 $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple
 	install -pm0644 -t $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple $(wildcard conf/apple/*)
-	install -dDm0755 $(DESTDIR)/$(TMPFILESDIR)
-	install -pm0644 speakersafetyd.tmpfiles $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
-	install -dDm0755 -o $(SPEAKERSAFETYD_USER) -g $(SPEAKERSAFETYD_GROUP) $(DESTDIR)/run/speakersafetyd
 
 uninstall:
-	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
+	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	rm -rf $(DESTDIR)/$(SHAREDIR)/speakersafetyd
 
 .PHONY: all install install-data uninstall

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ adapt for any device that provides V/ISENSE data in a manner similar to TAS2764.
 * Rust stable
 * alsa-lib
 * An Apple Silicon Mac running Asahi Linux
-* A `speakersafetyd` user in the `audio` group
+* A `speakersafetyd` user in the `audio` group (except if using systemd and `DynamicUser=yes`)
 
 ### Some background on Smart Amps
 The cheap component speaker elements used in modern devices like

--- a/speakersafetyd.service
+++ b/speakersafetyd.service
@@ -4,7 +4,11 @@ Description=Speaker Protection Daemon
 [Service]
 Type=simple
 ExecStart=/usr/bin/speakersafetyd -c /usr/share/speakersafetyd/ -m 7
+RuntimeDirectory=speakersafetyd
+DynamicUser=true
 User=speakersafetyd
+Group=speakersafetyd
+SupplementaryGroups=audio
 AmbientCapabilities=CAP_SYS_NICE
 CapabilityBoundingSet=CAP_SYS_NICE
 UMask=0066

--- a/speakersafetyd.tmpfiles
+++ b/speakersafetyd.tmpfiles
@@ -1,1 +1,0 @@
-d /run/speakersafetyd 0755 speakersafetyd speakersafetyd -


### PR DESCRIPTION
With the blackbox feature gone, there's no need to worry about state persisting across restarts, and for /run/speakersafetyd, we can use `RuntimeDirectory=speakersafetyd` to deal with the setup of that directory (instead of tmpfiles.d). This even includes cleanups.

Using DynamicUser=true also means there's no more need to setup the user manually. It'll be present as long as the service is running (except if still statically configured in /etc/passwd, which still works gracefully).

Closes #25.
Relates to #23.
Partial re-roll of #26.